### PR TITLE
django.conf.urls.defaults and django.utils.simplejson are deprecated

### DIFF
--- a/profiler/urls.py
+++ b/profiler/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import patterns, include, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, include, url
 
 urlpatterns = patterns(
     'profiler.views',

--- a/profiler/views.py
+++ b/profiler/views.py
@@ -4,7 +4,10 @@ from django.template.context import RequestContext
 from django.core.cache import cache
 from django.contrib.auth.decorators import user_passes_test
 from django.core.urlresolvers import reverse
-from django.utils import simplejson
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 
 from aggregate.client import get_client
 
@@ -42,7 +45,7 @@ def stats_by_view(request):
            
     return render_to_response('profiler/by_view.html',
                               {'queries' : grouped,
-                               'stats' :simplejson.dumps(stats)},
+                               'stats' : json.dumps(stats)},
                               context_instance=RequestContext(request))
 
 @user_passes_test(lambda u:u.is_superuser)


### PR DESCRIPTION
Both django.conf.urls.defaults and django.utils.simplejson are deprecated.

For backward compatibility, this safely try importing django.conf.urls first, fallback to django.conf.urls.defaults later.
